### PR TITLE
fix: syntax error in file dovetail.scad, line 119

### DIFF
--- a/dovetail.scad
+++ b/dovetail.scad
@@ -116,7 +116,7 @@ module cutter(position, dimension, teeths, male=true, debug=false) {
                 cube(size = dimension);
             }
         } else {
-            translate([- dimension[0] / 2, teeths[1] / 2 - 0.1, , - dimension[2] / 2]) {
+            translate([- dimension[0] / 2, teeths[1] / 2 - 0.1, - dimension[2] / 2]) {
                 cube(size = dimension);
             }
         }


### PR DESCRIPTION
Disclosure: I'm new to OpenSCAD and 3D Printing, so I might be wrong here.

I'm using `OpenSCAD-2023.07.28` development snapshot.

NOTE: In the latest stable release `OpenSCAD 2021.01` I do not get the error, so I'm not sure if the stable version was able to somehow understand and fix the syntax error, or if the new dev snapshot doesn't allow an empty third parameter anymore.

## Before

```
[ERROR: Parser error: syntax error in file dovetail.scad, line 119]
Execution aborted
```

## Adding `0`

Adding a `0` didn't help.

```diff
- translate([- dimension[0] / 2, teeths[1] / 2 - 0.1, , - dimension[2] / 2]) {
+ translate([- dimension[0] / 2, teeths[1] / 2 - 0.1, 0, - dimension[2] / 2]) {
```

I get the following warning:

```
[WARNING: Unable to convert translate([-78.6688, 3.9, 0, -2.5]) parameter to a vec3 or vec2 of numbers in file dovetail.scad, line 119]
```

<img width="817" alt="Screen Shot 2023-07-29 at 9 34 22 AM" src="https://github.com/hugokernel/OpenSCAD_Dovetail/assets/8354571/91f4eaf2-b1a1-490b-b721-1989ff6cc998">

## Remove comma

Removing the comma seems to fix it, but I'm not sure if this would have come underlying consequences.

<img width="819" alt="Screen Shot 2023-07-29 at 9 40 07 AM" src="https://github.com/hugokernel/OpenSCAD_Dovetail/assets/8354571/e3f7d47c-2061-4361-9b99-f48085839ee4">